### PR TITLE
Set CFBundleShortVersionString to match last tag

### DIFF
--- a/Tyro/Info.plist
+++ b/Tyro/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This fixes the version number of the framework. Ideally the current tag 0.0.9 should be updated.

This solves false positive when running fastlane action check_dependencies